### PR TITLE
Fix python module in rootfs build

### DIFF
--- a/samplefs/make_ubuntu_samplefs.sh
+++ b/samplefs/make_ubuntu_samplefs.sh
@@ -25,7 +25,7 @@ apt_mirror="http://localhost:3142/${UBUNTU_MIRROR}"
 apt_extra="-o Acquire::http::Proxy=\"http://localhost:3142\""
 
 PYTHON_PACKAGE_LIST="numpy==1.26.4 opencv-python pySerial i2cdev spidev matplotlib pillow \
-websocket websockets lark-parser netifaces google protobuf==3.20.1 "
+websockets lark-parser netifaces google protobuf==3.20.1 "
 
 DEBOOTSTRAP_LIST="systemd sudo locales apt-utils init dbus kmod udev bash-completion ntp libjsoncpp-dev libjson-c-dev rapidjson-dev libgpiod2 libgpiod-dev libdrm-dev libevent-dev kcapi-tools libkcapi-dev libminizip-dev libhidapi-libusb0 can-utils dnsmasq linuxptp libpcap-dev"
 


### PR DESCRIPTION
问题描述：
在编译rootfs的过程中，出现以下日志中的问题
<img width="1280" height="899" alt="image" src="https://github.com/user-attachments/assets/f25dff6d-5f10-48e9-98b3-cabec39706d9" />

问题日志：
Get:1 http://packages.ros.org/ros2/ubuntu jammy InRelease [4682 B]
Hit:2 http://mirrors4.tuna.tsinghua.edu.cn/ubuntu-ports jammy InRelease
Get:3 http://packages.ros.org/ros2/ubuntu jammy/main Sources [1796 kB]
Hit:4 http://mirrors4.tuna.tsinghua.edu.cn/ubuntu-ports jammy-security InRelease
Get:5 http://packages.ros.org/ros2/ubuntu jammy/main arm64 Packages [1723 kB]
Hit:6 http://mirrors4.tuna.tsinghua.edu.cn/ubuntu-ports jammy-updates InRelease
Hit:7 http://mirrors4.tuna.tsinghua.edu.cn/ubuntu-ports jammy-backports InRelease
Fetched 3524 kB in 8s (416 kB/s)
perl: warning: Setting locale failed.
perl: warning: Please check that your locale settings:
        LANGUAGE = (unset),
        LC_ALL = (unset),
        LANG = "en_US.UTF-8"
    are supported and installed on your system.
perl: warning: Falling back to the standard locale ("C").
Reading package lists... Done
Reading package lists... Done
Building dependency tree... Done
Reading state information... Done
python3-colcon-common-extensions is already the newest version (0.3.0-100).
ros-dev-tools is already the newest version (1.0.1).
ros-humble-desktop is already the newest version (0.10.0-1jammy.20260326.171928).
The following package was automatically installed and is no longer required:
  libllvm13
Use 'apt autoremove' to remove it.
0 upgraded, 0 newly installed, 0 to remove and 9 not upgraded.
Hit:1 http://packages.ros.org/ros2/ubuntu jammy InRelease
Hit:2 http://mirrors4.tuna.tsinghua.edu.cn/ubuntu-ports jammy InRelease
Hit:3 http://mirrors4.tuna.tsinghua.edu.cn/ubuntu-ports jammy-security InRelease
Hit:4 http://mirrors4.tuna.tsinghua.edu.cn/ubuntu-ports jammy-updates InRelease
Hit:5 http://mirrors4.tuna.tsinghua.edu.cn/ubuntu-ports jammy-backports InRelease
perl: warning: Setting locale failed.
perl: warning: Please check that your locale settings:
        LANGUAGE = (unset),
        LC_ALL = (unset),
        LANG = "en_US.UTF-8"
    are supported and installed on your system.
perl: warning: Falling back to the standard locale ("C").
Reading package lists... Done
Reading package lists... Done
Building dependency tree... Done
Reading state information... Done
python3-colcon-common-extensions is already the newest version (0.3.0-100).
ros-dev-tools is already the newest version (1.0.1).
ros-humble-desktop is already the newest version (0.10.0-1jammy.20260326.171928).
The following package was automatically installed and is no longer required:
  libllvm13
Use 'apt autoremove' to remove it.
0 upgraded, 0 newly installed, 0 to remove and 9 not upgraded.
Hit:1 http://packages.ros.org/ros2/ubuntu jammy InRelease
Hit:2 http://mirrors4.tuna.tsinghua.edu.cn/ubuntu-ports jammy InRelease
Hit:3 http://mirrors4.tuna.tsinghua.edu.cn/ubuntu-ports jammy-security InRelease
Hit:4 http://mirrors4.tuna.tsinghua.edu.cn/ubuntu-ports jammy-updates InRelease
Hit:5 http://mirrors4.tuna.tsinghua.edu.cn/ubuntu-ports jammy-backports InRelease
perl: warning: Setting locale failed.
perl: warning: Please check that your locale settings:
        LANGUAGE = (unset),
        LC_ALL = (unset),
        LANG = "en_US.UTF-8"
    are supported and installed on your system.
perl: warning: Falling back to the standard locale ("C").
Reading package lists... Done
Reading package lists... Done
Building dependency tree... Done
Reading state information... Done
python3-colcon-common-extensions is already the newest version (0.3.0-100).
ros-dev-tools is already the newest version (1.0.1).
ros-humble-desktop is already the newest version (0.10.0-1jammy.20260326.171928).
The following package was automatically installed and is no longer required:
  libllvm13
Use 'apt autoremove' to remove it.
0 upgraded, 0 newly installed, 0 to remove and 9 not upgraded.
Reading package lists... Done
Building dependency tree... Done
Reading state information... Done
Package 'brltty' is not installed, so not removed
The following package was automatically installed and is no longer required:
  libllvm13
Use 'apt autoremove' to remove it.
0 upgraded, 0 newly installed, 0 to remove and 9 not upgraded.
Reading package lists... Done
Building dependency tree... Done
Reading state information... Done
Calculating upgrade... Done
The following package was automatically installed and is no longer required:
  libllvm13
Use 'apt autoremove' to remove it.
The following packages have been kept back:
  cpp-11 g++-11 gcc-11 gcc-11-base libasan6 libgcc-11-dev libstdc++-11-dev libtsan0
The following packages will be upgraded:
  python3-bloom
1 upgraded, 0 newly installed, 0 to remove and 8 not upgraded.
Need to get 71.9 kB of archives.
After this operation, 0 B of additional disk space will be used.
Get:1 http://packages.ros.org/ros2/ubuntu jammy/main arm64 python3-bloom all 0.14.1+upstream-1 [71.9 kB]
Fetched 71.9 kB in 1s (83.2 kB/s)
perl: warning: Setting locale failed.
perl: warning: Please check that your locale settings:
        LANGUAGE = (unset),
        LC_ALL = (unset),
        LANG = "en_US.UTF-8"
    are supported and installed on your system.
perl: warning: Falling back to the standard locale ("C").
locale: Cannot set LC_CTYPE to default locale: No such file or directory
locale: Cannot set LC_MESSAGES to default locale: No such file or directory
locale: Cannot set LC_ALL to default locale: No such file or directory
(Reading database ... 173886 files and directories currently installed.)
Preparing to unpack .../python3-bloom_0.14.1+upstream-1_all.deb ...
Unpacking python3-bloom (0.14.1+upstream-1) over (0.14.0+upstream-1) ...
Setting up python3-bloom (0.14.1+upstream-1) ...
Reading package lists... Done
Building dependency tree... Done
Reading state information... Done
libpcl-dev is already the newest version (1.12.1+dfsg-3build1).
libpcl-dev set to manually installed.
ocl-icd-libopencl1 is already the newest version (2.2.14-3).
ocl-icd-libopencl1 set to manually installed.
The following package was automatically installed and is no longer required:
  libllvm13
Use 'apt autoremove' to remove it.
Suggested packages:
  opencl-clhpp-headers-doc
The following NEW packages will be installed:
  libgles2-mesa-dev opencl-c-headers opencl-clhpp-headers opencl-headers
0 upgraded, 4 newly installed, 0 to remove and 8 not upgraded.
Need to get 95.7 kB of archives.
After this operation, 801 kB of additional disk space will be used.
Get:1 http://mirrors4.tuna.tsinghua.edu.cn/ubuntu-ports jammy-updates/main arm64 libgles2-mesa-dev arm64 23.2.1-1ubuntu3.1~22.04.3 [6854 B]
Get:2 http://mirrors4.tuna.tsinghua.edu.cn/ubuntu-ports jammy/universe arm64 opencl-c-headers all 3.0~2022.01.04-1 [44.5 kB]
Get:3 http://mirrors4.tuna.tsinghua.edu.cn/ubuntu-ports jammy/universe arm64 opencl-clhpp-headers all 3.0~2.0.15-1ubuntu1 [42.6 kB]
Get:4 http://mirrors4.tuna.tsinghua.edu.cn/ubuntu-ports jammy/universe arm64 opencl-headers all 3.0~2022.01.04-1 [1754 B]
Fetched 95.7 kB in 7s (13.2 kB/s)
perl: warning: Setting locale failed.
perl: warning: Please check that your locale settings:
        LANGUAGE = (unset),
        LC_ALL = (unset),
        LANG = "en_US.UTF-8"
    are supported and installed on your system.
perl: warning: Falling back to the standard locale ("C").
locale: Cannot set LC_CTYPE to default locale: No such file or directory
locale: Cannot set LC_MESSAGES to default locale: No such file or directory
locale: Cannot set LC_ALL to default locale: No such file or directory
Selecting previously unselected package libgles2-mesa-dev:arm64.
(Reading database ... 173886 files and directories currently installed.)
Preparing to unpack .../libgles2-mesa-dev_23.2.1-1ubuntu3.1~22.04.3_arm64.deb ...
Unpacking libgles2-mesa-dev:arm64 (23.2.1-1ubuntu3.1~22.04.3) ...
Selecting previously unselected package opencl-c-headers.
Preparing to unpack .../opencl-c-headers_3.0~2022.01.04-1_all.deb ...
Unpacking opencl-c-headers (3.0~2022.01.04-1) ...
Selecting previously unselected package opencl-clhpp-headers.
Preparing to unpack .../opencl-clhpp-headers_3.0~2.0.15-1ubuntu1_all.deb ...
Unpacking opencl-clhpp-headers (3.0~2.0.15-1ubuntu1) ...
Selecting previously unselected package opencl-headers.
Preparing to unpack .../opencl-headers_3.0~2022.01.04-1_all.deb ...
Unpacking opencl-headers (3.0~2022.01.04-1) ...
Setting up libgles2-mesa-dev:arm64 (23.2.1-1ubuntu3.1~22.04.3) ...
Setting up opencl-c-headers (3.0~2022.01.04-1) ...
Setting up opencl-clhpp-headers (3.0~2.0.15-1ubuntu1) ...
Setting up opencl-headers (3.0~2022.01.04-1) ...
Writing to /root/.config/pip/pip.conf
Writing to /root/.config/pip/pip.conf
Looking in indexes: https://pypi.tuna.tsinghua.edu.cn/simple
Collecting numpy==1.26.4
  Downloading https://pypi.tuna.tsinghua.edu.cn/packages/fc/a5/4beee6488160798683eed5bdb7eead455892c3b4e1f78d79d8d3f3b084ac/numpy-1.26.4-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl (14.2 MB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 14.2/14.2 MB 9.7 MB/s eta 0:00:00
Collecting opencv-python
  Downloading https://pypi.tuna.tsinghua.edu.cn/packages/02/6d/7a9cc719b3eaf4377b9c2e3edeb7ed3a81de41f96421510c0a169ca3cfd4/opencv_python-4.13.0.92-cp37-abi3-manylinux_2_28_aarch64.whl (46.7 MB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 46.7/46.7 MB 9.0 MB/s eta 0:00:00
Requirement already satisfied: pySerial in /usr/lib/python3/dist-packages (3.5)
Collecting i2cdev
  Downloading https://pypi.tuna.tsinghua.edu.cn/packages/28/3e/fb40016e8b61d8346ad41ee326eae46086c8aa3c43d57b1cc1a8bb9156ee/i2cdev-1.2.4.tar.gz (1.6 kB)
  Preparing metadata (setup.py) ... done
Collecting spidev
  Downloading https://pypi.tuna.tsinghua.edu.cn/packages/67/87/039b6eeea781598015b538691bc174cc0bf77df9d4d2d3b8bf9245c0de8c/spidev-3.8.tar.gz (13 kB)
  Installing build dependencies ... done
  Getting requirements to build wheel ... done
  Installing backend dependencies ... done
  Preparing metadata (pyproject.toml) ... done
Requirement already satisfied: matplotlib in /usr/lib/python3/dist-packages (3.5.1)
Requirement already satisfied: pillow in /usr/lib/python3/dist-packages (9.0.1)
Collecting websocket
  Downloading https://pypi.tuna.tsinghua.edu.cn/packages/f2/6d/a60d620ea575c885510c574909d2e3ed62129b121fa2df00ca1c81024c87/websocket-0.2.1.tar.gz (195 kB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 195.3/195.3 KB 6.0 MB/s eta 0:00:00
  Preparing metadata (setup.py) ... done
Collecting websockets
  Downloading https://pypi.tuna.tsinghua.edu.cn/packages/86/26/d40eaa2a46d4302becec8d15b0fc5e45bdde05191e7628405a19cf491ccd/websockets-16.0-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl (185 kB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 185.1/185.1 KB 8.6 MB/s eta 0:00:00
Collecting lark-parser
  Downloading https://pypi.tuna.tsinghua.edu.cn/packages/76/00/90f05db333fe1aa6b6ffea83a35425b7d53ea95c8bba0b1597f226cf1d5f/lark_parser-0.12.0-py2.py3-none-any.whl (103 kB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 103.5/103.5 KB 6.9 MB/s eta 0:00:00
Requirement already satisfied: netifaces in /usr/lib/python3/dist-packages (0.11.0)
Collecting google
  Downloading https://pypi.tuna.tsinghua.edu.cn/packages/ac/35/17c9141c4ae21e9a29a43acdfd848e3e468a810517f862cad07977bf8fe9/google-3.0.0-py2.py3-none-any.whl (45 kB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 45.3/45.3 KB 3.2 MB/s eta 0:00:00
Collecting protobuf==3.20.1
  Downloading https://pypi.tuna.tsinghua.edu.cn/packages/70/75/df318e565cf126a9464b9220ef6adfecb44fb7c68df140bc5680d0ed05c3/protobuf-3.20.1-cp310-cp310-manylinux2014_aarch64.whl (917 kB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 917.9/917.9 KB 12.1 MB/s eta 0:00:00
Collecting opencv-python
  Downloading https://pypi.tuna.tsinghua.edu.cn/packages/fc/1c/87fa71968beb71481ed359e21772061ceff7c9b45a61b3e7daa71e5b0b66/opencv_python-4.13.0.90-cp37-abi3-manylinux_2_28_aarch64.whl (46.7 MB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 46.7/46.7 MB 9.2 MB/s eta 0:00:00
  Downloading https://pypi.tuna.tsinghua.edu.cn/packages/62/3a/440bd64736cf8116f01f3b7f9f2e111afb2e02beb2ccc08a6458114a6b5d/opencv_python-4.12.0.88-cp37-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl (45.9 MB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 45.9/45.9 MB 9.2 MB/s eta 0:00:00
  Downloading https://pypi.tuna.tsinghua.edu.cn/packages/f3/bd/29c126788da65c1fb2b5fb621b7fed0ed5f9122aa22a0868c5e2c15c6d23/opencv_python-4.11.0.86-cp37-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl (42.2 MB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 42.2/42.2 MB 9.2 MB/s eta 0:00:00
Collecting gevent
  Downloading https://pypi.tuna.tsinghua.edu.cn/packages/20/27/1062fa31333dc3428a1f5f33cd6598b0552165ba679ca3ba116de42c9e8e/gevent-26.4.0.tar.gz (6.2 MB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 6.2/6.2 MB 10.7 MB/s eta 0:00:00
  Installing build dependencies ... done
  Getting requirements to build wheel ... error
  error: subprocess-exited-with-error

  × Getting requirements to build wheel did not run successfully.
  │ exit code: 1
  ╰─> [44 lines of output]
      Compiling src/gevent/resolver/cares.pyx because it depends on /tmp/pip-build-env-l1fq7s5d/overlay/local/lib/python3.10/dist-packages/Cython/Includes/libc/string.pxd.
      [1/1] Cythonizing src/gevent/resolver/cares.pyx
      Compiling src/gevent/libev/corecext.pyx because it depends on /tmp/pip-build-env-l1fq7s5d/overlay/local/lib/python3.10/dist-packages/Cython/Includes/libc/string.pxd.
      [1/1] Cythonizing src/gevent/libev/corecext.pyx
      Traceback (most recent call last):
        File "/usr/lib/python3/dist-packages/pip/_vendor/pep517/in_process/_in_process.py", line 363, in <module>
          main()
        File "/usr/lib/python3/dist-packages/pip/_vendor/pep517/in_process/_in_process.py", line 345, in main
          json_out['return_val'] = hook(**hook_input['kwargs'])
        File "/usr/lib/python3/dist-packages/pip/_vendor/pep517/in_process/_in_process.py", line 130, in get_requires_for_build_wheel
          return hook(config_settings)
        File "/usr/lib/python3/dist-packages/setuptools/build_meta.py", line 162, in get_requires_for_build_wheel
          return self._get_build_requires(
        File "/usr/lib/python3/dist-packages/setuptools/build_meta.py", line 143, in _get_build_requires
          self.run_setup()
        File "/usr/lib/python3/dist-packages/setuptools/build_meta.py", line 158, in run_setup
          exec(compile(code, file, 'exec'), locals())
        File "setup.py", line 472, in <module>
          run_setup(EXT_MODULES)
        File "setup.py", line 338, in run_setup
          setup(
        File "/usr/lib/python3/dist-packages/setuptools/init.py", line 153, in setup
          return distutils.core.setup(**attrs)
        File "/usr/lib/python3/dist-packages/setuptools/_distutils/core.py", line 109, in setup
          _setup_distribution = dist = klass(attrs)
        File "/usr/lib/python3/dist-packages/setuptools/dist.py", line 459, in init
          _Distribution.init(
        File "/usr/lib/python3/dist-packages/setuptools/_distutils/dist.py", line 293, in init
          self.finalize_options()
        File "/usr/lib/python3/dist-packages/setuptools/dist.py", line 837, in finalize_options
          ep(self)
        File "/usr/lib/python3/dist-packages/setuptools/dist.py", line 858, in _finalize_setup_keywords
          ep.load()(self, ep.name, value)
        File "/tmp/pip-build-env-l1fq7s5d/overlay/local/lib/python3.10/dist-packages/cffi/setuptools_ext.py", line 229, in cffi_modules
          add_cffi_module(dist, cffi_module)
        File "/tmp/pip-build-env-l1fq7s5d/overlay/local/lib/python3.10/dist-packages/cffi/setuptools_ext.py", line 50, in add_cffi_module
          execfile(build_file_name, mod_vars)
        File "/tmp/pip-build-env-l1fq7s5d/overlay/local/lib/python3.10/dist-packages/cffi/setuptools_ext.py", line 26, in execfile
          exec(code, glob, glob)
        File "src/gevent/libev/_corecffi_build.py", line 31, in <module>
          ffi = FFI()
        File "/tmp/pip-build-env-l1fq7s5d/overlay/local/lib/python3.10/dist-packages/cffi/api.py", line 54, in init
          raise Exception("Version mismatch: this is the 'cffi' package version %s, located in %r.  When we import the top-level '_cffi_backend' extension module, we get version %s, located in %r.  The two versions should be equal; check your installation." % (
      Exception: Version mismatch: this is the 'cffi' package version 2.0.0, located in '/tmp/pip-build-env-l1fq7s5d/overlay/local/lib/python3.10/dist-packages/cffi/api.py'.  When we import the top-level '_cffi_backend' extension module, we get version 1.15.0, located in '/usr/lib/python3/dist-packages/_cffi_backend.cpython-310-aarch64-linux-gnu.so'.  The two versions should be equal; check your installation.
      [end of output]

  note: This error originates from a subprocess, and is likely not a problem with pip.
error: subprocess-exited-with-error

× Getting requirements to build wheel did not run successfully.
│ exit code: 1
╰─> See above for output.

note: This error originates from a subprocess, and is likely not a problem with pip.
[ o.k. ] Unmounting [ /opt/atom01/x5-rdk-gen/samplefs/desktop/jammy-rdk-arm64/ ]
root@roboa100:/opt/atom01/x5-rdk-gen#