### PR TITLE
perf(mk_debs.h mk_kernel.sh mk_kernel_rt.sh): [RDK-1498] Use the compressed kernel Image.lz4 to optimize the boot speed

### DIFF
--- a/mk_debs.sh
+++ b/mk_debs.sh
@@ -175,8 +175,8 @@ function make_debian_deb() {
 
         boot_dest_dir=${deb_dst_dir}/boot
         mkdir -p "${boot_dest_dir}"
-        cp -arf "${IMAGE_DEPLOY_DIR}"/kernel/Image  "${boot_dest_dir}"/
-        cp -arf "${IMAGE_DEPLOY_DIR}"/kernel/Image-rt  "${boot_dest_dir}"/ || true
+        cp -arf "${IMAGE_DEPLOY_DIR}"/kernel/Image.lz4  "${boot_dest_dir}"/
+        cp -arf "${IMAGE_DEPLOY_DIR}"/kernel/Image-rt.lz4  "${boot_dest_dir}"/ || true
         cp -arf "${KERNEL_DEPLOY_DIR}"/modules/* "${deb_dst_dir}"/
         cp -arf "${debian_src_dir}"/"${pkg_name}"/debian/boot/boot.scr "${deb_dst_dir}"/boot/
         case "$RDK_SOC_NAME" in

--- a/mk_kernel.sh
+++ b/mk_kernel.sh
@@ -200,7 +200,7 @@ function build_all()
     rm -rf "${KO_INSTALL_DIR}"/lib/modules/"${KERNEL_VER}"/{build,source}
 
     # 拷贝 内核 Image
-    cp -f "arch/arm64/boot/Image" "${KERNEL_BUILD_DIR}"/
+    cp -f "arch/arm64/boot/Image.lz4" "${KERNEL_BUILD_DIR}"/
 
     # 生成 dtb 镜像
     mkdir -p "${KERNEL_BUILD_DIR}"/dtb

--- a/mk_kernel_rt.sh
+++ b/mk_kernel_rt.sh
@@ -219,7 +219,7 @@ function build_all()
     rm -rf "${KO_INSTALL_DIR}"/lib/modules/"${KERNEL_VER}"/{build,source}
 
     # 拷贝 内核 Image
-    cp -f "arch/arm64/boot/Image" "${KERNEL_BUILD_DIR}"/Image-rt
+    cp -f "arch/arm64/boot/Image.lz4" "${KERNEL_BUILD_DIR}"/Image-rt.lz4
 
     # 生成内核头文件
     make_kernel_headers


### PR DESCRIPTION
perf(mk_debs.h mk_kernel.sh mk_kernel_rt.sh): [RDK-1498] Use the compressed kernel Image.lz4 to optimize the boot speed